### PR TITLE
Enable Travis CI for ACDC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+compiler:
+- gcc
+install:
+  - ./install_deps.sh
+  - ./build/gyp/gyp --depth=. acdc.gyp
+script:
+  - BUILDTYPE=Release make


### PR DESCRIPTION
The .travis.yml builds acdc with a Linux+gcc configuration and skips the installation of third-party allocators.